### PR TITLE
feat(normalize_url): check for trailing ampersand

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,8 +62,8 @@ fn normalize_url(mut parsed: Url) -> String {
         url.pop();
     }
 
-    // replace trailing ?
-    if url.ends_with('?') {
+    // replace trailing ? and &
+    if url.ends_with(['?', '&']) {
         url.pop();
     }
 
@@ -272,6 +272,14 @@ mod tests {
     fn test_generate_surt_with_ftp_url() {
         let url = "ftp://www.example.com";
         assert!(generate_surt(url).is_err());
+    }
+
+    #[test]
+    fn test_generate_surt_with_magic_ampersand() {
+        let url = "http://www.example.com/khxc/index.php?app=ccp0&ns=catshow&ref=kawasaki&prodsort=PRICEUP&sid=ze2509b1v54ldiu17199jlcf8n88cquz";
+        let expected =
+            "com,example)/khxc/index.php?app=ccp0&ns=catshow&prodsort=priceup&ref=kawasaki";
+        assert_eq!(generate_surt(url).unwrap(), expected);
     }
 
     #[test]


### PR DESCRIPTION
Remove trailing ampersand along with trailing question mark, along with [a test case](https://web.archive.org/web/20250325063032/https://webarchivingbucket.com/techblog/?p=48) inspired by Younès Hafri.

I'm not entirely sure eliminating the trailing ampersand is necessary, so this PR is only a speculative fix depending on whether or not it's considered expected behaviour.

This PR would close #9 